### PR TITLE
Fix vertical align for the slide content.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
 </head>
 <body>
     <div id="slide1" class="slide">
-        <a href="#slide2">Go to Slide 2</a>
+        <a href="#slide2">Go to Slide 2<br />Any size of content can be here.<br />It will always be centered vertically and horizontally.</a>
     </div>
     <div id="slide2" class="slide">
-        <a href="#slide3">Go to Slide 3</a>
+        <a href="#slide3">Go to Slide 3.</a>
     </div>
     <div id="slide3" class="slide">
         <a href="#slideEnd">End the slideshow</a>

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,38 @@
 html, body {
     height: 100%;
-    min-height: 100%;
     margin: 0;
-    text-align: center;
-    position: relative;
 }
+
 .slide {
-    min-height: 100%; 
-    position: relative;
+    text-align: center;
+    height: 100%;
 }
-.slide a {
-    position: absolute;
-    top: 50%;
-    height: 10em;
-    margin-top: -5em;
-    margin-left: -3em;
+
+/**
+    The idea behind this is to use the pseudo class :before with height same as parent.
+    Set it as inline-block to make it possible to use of vertical align. Next the font-size
+    is set to '0' to make sure if the pseudo content don't take up any space itself.
+*/
+.slide:before{
+    content: '';
+    height: 100%;
+    display: inline-block;
+    font-size: 0;
+    vertical-align: middle;
 }
+
+/**
+    Assume the :before as an element just before the slide's inner content. Now make
+    vertical align to middle. This will keep the content in absolute vertical central
+*/
+
+.slide > *{
+    display: inline-block;
+    vertical-align: middle;
+}
+
 #slide1 {
-    background: LightSalmon; 
+    background: LightSalmon;
 }
 #slide2 {
     background: LightCoral;
@@ -28,13 +43,8 @@ html, body {
 #slideEnd {
     background: black;
 }
+
 #slideEnd span {
     color: white;
     text-decoration: none;
-
-    position: absolute;
-    top: 50%;
-    height: 10em;
-    margin-top: -5em;
-    margin-left: -3em;
 }


### PR DESCRIPTION
Fix for your issue: #2 #4 

The idea behind this is to use the pseudo class :before with height same as parent. Set it as inline-block to make it possible to use of vertical align. Next the font-size is set to '0' to make sure if the pseudo content don't take up any space itself.

Assume the :before as an element just before the slide's inner content. Now make vertical align to middle. This will keep the content in absolute vertical central.
